### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/wp-phpunit.yml
+++ b/.github/workflows/wp-phpunit.yml
@@ -43,7 +43,7 @@ jobs:
       run: php -v
 
     - name: Composer install
-      run: composer require yoast/phpunit-polyfills:"*"; composer require phpunit/phpunit:"${{ matrix.phpunit-versions }}" --with-all-dependencies; composer install --optimize-autoloader --prefer-dist; phpunit --version; ./vendor/phpunit/phpunit/phpunit --version
+      run: composer install --optimize-autoloader --prefer-dist
 
     - name: Start Mysql
       run: sudo service mysql start
@@ -52,4 +52,6 @@ jobs:
       run: bash bin/install-wp-tests.sh wordpress_test root root localhost latest
 
     - name: phpunit tests
-      run: ./vendor/phpunit/phpunit/phpunit --config=phpunit.xml
+      run: |
+        echo "define('WP_TESTS_PHPUNIT_POLYFILLS_PATH', '$HOME/.composer/vendor/yoast/phpunit-polyfills');" >> /tmp/wordpress-tests-lib/wp-tests-config.php
+        /usr/local/bin/phpunit --config=phpunit.xml


### PR DESCRIPTION
This PR should fix the `wp-phpunit.yml` workflow.

`PHPUnit-polyfills` installs a `PHPUnit` version which is different from the one setup-php installs as per the workflow and in the PATH the one installed by `PHPUnit-polyfills` was first, so as a workaround until I find a better solution for this, the full path to the `PHPUnit` installed by setup-php can be used.

When you use a different `PHPUnit` from the one `PHPUnit-polyfills` installed, as per the logs it says to set `WP_TESTS_PHPUNIT_POLYFILLS_PATH` constant, so this PR also sets that in `wordpress-tests-lib` before running PHPUnit.